### PR TITLE
correctly handling optional xml elements in golang

### DIFF
--- a/genGo.go
+++ b/genGo.go
@@ -218,11 +218,15 @@ func (gen *CodeGenerator) GoComplexType(v *ComplexType) {
 			if element.Plural {
 				plural = "[]"
 			}
+			var optional string
+			if element.Optional {
+				optional = `,omitempty`
+			}
 			fieldType := genGoFieldType(getBasefromSimpleType(trimNSPrefix(element.Type), gen.ProtoTree))
 			if fieldType == "time.Time" {
 				gen.ImportTime = true
 			}
-			content += fmt.Sprintf("\t%s\t%s%s\t`xml:\"%s\"`\n", genGoFieldName(element.Name, false), plural, fieldType, element.Name)
+			content += fmt.Sprintf("\t%s\t%s%s\t`xml:\"%s%s\"`\n", genGoFieldName(element.Name, false), plural, fieldType, element.Name, optional)
 		}
 		if len(v.Base) > 0 {
 			// If the type is a built-in type, generate a Value field as chardata.

--- a/xmlElement.go
+++ b/xmlElement.go
@@ -48,6 +48,11 @@ func (opt *Options) OnElement(ele xml.StartElement, protoTree []interface{}) (er
 				e.Plural = true
 			}
 		}
+		if attr.Name.Local == "minOccurs" {
+			if attr.Value == "0" {
+				e.Optional = true
+			}
+		}
 	}
 
 	if e.Type == "" {


### PR DESCRIPTION
# PR Details

Fixed handling of optional XML Elements. When an element has set minOccurs in the XSD it should be marked as optional and receive the `omitEmpty` tag in Golang.

## Description

Fixed handling of optional XML Elements. When an element has set minOccurs in the XSD it should be marked as optional and receive the `omitEmpty` tag in Golang.

## Related Issue

https://github.com/xuri/xgen/issues/47

## Motivation and Context

Without this fix, struct tags for are generated incorrectly and optional XML Element will be present as empty XML elements.

## How Has This Been Tested

ran original tests.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.
