### PR TITLE
adding ingnore naming commandline flag

### DIFF
--- a/cmd/xgen/xgen.go
+++ b/cmd/xgen/xgen.go
@@ -12,6 +12,7 @@
 //        -o <path> Output file path or directory for the generated code
 //        -p        Specify the package name
 //        -l        Specify the language of generated code (Go/C/Java/Rust/TypeScript)
+//        -inc      Ignore name conflict in Golang
 //        -h        Output this help and exit
 //        -v        Output version and exit
 //
@@ -36,6 +37,7 @@ import (
 // generating source code from an XSD document.
 type Config struct {
 	I       string
+	Inc     bool
 	O       string
 	Pkg     string
 	Lang    string
@@ -66,6 +68,7 @@ func parseFlags() *Config {
 	langPtr := flag.String("l", "", "Specify the language of generated code")
 	verPtr := flag.Bool("v", false, "Show version and exit")
 	helpPtr := flag.Bool("h", false, "Show this help and exit")
+	incPtr := flag.Bool("inc", false, "Ignore the name conflict between field name and tag")
 	flag.Parse()
 	if *helpPtr {
 		fmt.Printf("xgen version: %s\r\nCopyright (c) 2020 - 2022 Ri Xu https://xuri.me All rights reserved.\r\n\r\nUsage:\r\n$ xgen [<flag> ...] <XSD file or directory> ...\n  -i <path>\tInput file path or directory for the XML schema definition\r\n  -o <path>\tOutput file path or directory for the generated code\r\n  -p     \tSpecify the package name\r\n  -l      \tSpecify the language of generated code (Go/C/Java/Rust/TypeScript)\r\n  -h     \tOutput this help and exit\r\n  -v     \tOutput version and exit\r\n", Cfg.Version)
@@ -84,6 +87,9 @@ func parseFlags() *Config {
 		fmt.Println("must specify the language of generated code (Go/C/Java/Rust/TypeScript)")
 		os.Exit(1)
 	}
+
+	Cfg.Inc = *incPtr
+
 	Cfg.Lang = *langPtr
 	if *oPtr != "" {
 		Cfg.O = *oPtr
@@ -112,6 +118,7 @@ func main() {
 			OutputDir:           cfg.O,
 			Lang:                cfg.Lang,
 			Package:             cfg.Pkg,
+			IgnoreNameConflict:  cfg.Inc,
 			IncludeMap:          make(map[string]bool),
 			LocalNameNSMap:      make(map[string]string),
 			NSSchemaLocationMap: make(map[string]string),

--- a/genGo.go
+++ b/genGo.go
@@ -19,14 +19,15 @@ import (
 // CodeGenerator holds code generator overrides and runtime data that are used
 // when generate code from proto tree.
 type CodeGenerator struct {
-	Lang              string
-	File              string
-	Field             string
-	Package           string
-	ImportTime        bool // For Go language
-	ImportEncodingXML bool // For Go language
-	ProtoTree         []interface{}
-	StructAST         map[string]string
+	Lang               string
+	File               string
+	Field              string
+	Package            string
+	IgnoreNameConflict bool
+	ImportTime         bool // For Go language
+	ImportEncodingXML  bool // For Go language
+	ProtoTree          []interface{}
+	StructAST          map[string]string
 }
 
 var goBuildinType = map[string]bool{
@@ -150,8 +151,10 @@ func (gen *CodeGenerator) GoSimpleType(v *SimpleType) {
 			content := " struct {\n"
 			fieldName := genGoFieldName(v.Name, true)
 			if fieldName != v.Name {
-				gen.ImportEncodingXML = true
-				content += fmt.Sprintf("\tXMLName\txml.Name\t`xml:\"%s\"`\n", v.Name)
+				if !gen.IgnoreNameConflict {
+					gen.ImportEncodingXML = true
+					content += fmt.Sprintf("\tXMLName\txml.Name\t`xml:\"%s\"`\n", v.Name)
+				}
 			}
 			for _, member := range toSortedPairs(v.MemberTypes) {
 				memberName := member.key
@@ -183,8 +186,10 @@ func (gen *CodeGenerator) GoComplexType(v *ComplexType) {
 		content := " struct {\n"
 		fieldName := genGoFieldName(v.Name, true)
 		if fieldName != v.Name {
-			gen.ImportEncodingXML = true
-			content += fmt.Sprintf("\tXMLName\txml.Name\t`xml:\"%s\"`\n", v.Name)
+			if !gen.IgnoreNameConflict {
+				gen.ImportEncodingXML = true
+				content += fmt.Sprintf("\tXMLName\txml.Name\t`xml:\"%s\"`\n", v.Name)
+			}
 		}
 		for _, attrGroup := range v.AttributeGroup {
 			fieldType := getBasefromSimpleType(trimNSPrefix(attrGroup.Ref), gen.ProtoTree)
@@ -251,8 +256,10 @@ func (gen *CodeGenerator) GoGroup(v *Group) {
 		content := " struct {\n"
 		fieldName := genGoFieldName(v.Name, true)
 		if fieldName != v.Name {
-			gen.ImportEncodingXML = true
-			content += fmt.Sprintf("\tXMLName\txml.Name\t`xml:\"%s\"`\n", v.Name)
+			if !gen.IgnoreNameConflict {
+				gen.ImportEncodingXML = true
+				content += fmt.Sprintf("\tXMLName\txml.Name\t`xml:\"%s\"`\n", v.Name)
+			}
 		}
 		for _, element := range v.Elements {
 			var plural string
@@ -283,8 +290,10 @@ func (gen *CodeGenerator) GoAttributeGroup(v *AttributeGroup) {
 		content := " struct {\n"
 		fieldName := genGoFieldName(v.Name, true)
 		if fieldName != v.Name {
-			gen.ImportEncodingXML = true
-			content += fmt.Sprintf("\tXMLName\txml.Name\t`xml:\"%s\"`\n", v.Name)
+			if !gen.IgnoreNameConflict {
+				gen.ImportEncodingXML = true
+				content += fmt.Sprintf("\tXMLName\txml.Name\t`xml:\"%s\"`\n", v.Name)
+			}
 		}
 		for _, attribute := range v.Attributes {
 			var optional string

--- a/parser.go
+++ b/parser.go
@@ -29,6 +29,7 @@ type Options struct {
 	Extract             bool
 	Lang                string
 	Package             string
+	IgnoreNameConflict  bool
 	IncludeMap          map[string]bool
 	LocalNameNSMap      map[string]string
 	NSSchemaLocationMap map[string]string

--- a/test/go/base64.xsd.go
+++ b/test/go/base64.xsd.go
@@ -50,7 +50,7 @@ type MyType7 struct {
 type TopLevel struct {
 	CostAttr        float64    `xml:"cost,attr,omitempty"`
 	LastUpdatedAttr string     `xml:"LastUpdated,attr,omitempty"`
-	Nested          *MyType7   `xml:"nested"`
+	Nested          *MyType7   `xml:"nested,omitempty"`
 	MyType1         []string   `xml:"myType1"`
 	MyType2         []*MyType2 `xml:"myType2"`
 	*MyType6

--- a/test/rs/base64.xsd.rs
+++ b/test/rs/base64.xsd.rs
@@ -84,7 +84,7 @@ pub struct TopLevel {
 	#[serde(rename = "LastUpdated")]
 	pub last_updated: Option<u8>,
 	#[serde(rename = "nested")]
-	pub nested: MyType7,
+	pub nested: Option<MyType7>,
 	#[serde(rename = "myType1")]
 	pub my_type1: Vec<String>,
 	#[serde(rename = "myType2")]


### PR DESCRIPTION
# PR Details

added command line option to not include the XML names in Golang

## Description

XML names cause issues for embedded Go structs

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
